### PR TITLE
Add FLASH region in etiss linker script

### DIFF
--- a/cmake/targets/etiss.cmake
+++ b/cmake/targets/etiss.cmake
@@ -57,7 +57,13 @@ MACRO(COMMON_ADD_LIBRARY TARGET_NAME)
     ENDIF()
 ENDMACRO()
 
-CONFIGURE_FILE(${CMAKE_CURRENT_LIST_DIR}/etiss/etiss.ld.in etiss.ld @ONLY)
+IF(DEFINED MEM_FLASH_ORIGIN AND NOT "${MEM_FLASH_ORIGIN}" STREQUAL "None" AND NOT "${MEM_FLASH_ORIGIN}" STREQUAL "")
+    set(LINKER_SCRIPT_TEMPLATE ${CMAKE_CURRENT_LIST_DIR}/etiss/etiss_wFlash.ld.in)
+ELSE()
+    set(LINKER_SCRIPT_TEMPLATE ${CMAKE_CURRENT_LIST_DIR}/etiss/etiss.ld.in)
+ENDIF()
+
+CONFIGURE_FILE(${LINKER_SCRIPT_TEMPLATE} etiss.ld @ONLY)
 
 # The linker argument setting will break the cmake test program on 64-bit,
 # so disable test program linking for now.

--- a/cmake/targets/etiss/etiss.ld.in
+++ b/cmake/targets/etiss/etiss.ld.in
@@ -20,6 +20,7 @@ MEMORY
 {
   ROM  (rx)  : ORIGIN = @MEM_ROM_ORIGIN@, LENGTH = @MEM_ROM_LENGTH@
   RAM  (rw) : ORIGIN = @MEM_RAM_ORIGIN@, LENGTH = @MEM_RAM_LENGTH@
+  FLASH  (rw) : ORIGIN = @MEM_FLASH_ORIGIN@, LENGTH = @MEM_FLASH_LENGTH@
 }
 
 
@@ -36,10 +37,6 @@ _heap_end        = _stack_start;
 SECTIONS
 {
   /* ================ ROM ================ */
-
-  .text : {
-    *(.text .text.* )
-  }  > ROM
 
   .rodata : {
     *(.rodata .rodata.*)
@@ -100,4 +97,10 @@ SECTIONS
   .stack : {
     ASSERT ((__stack > (_end + __heap_size + __stack_size)), "Error: RAM too small for heap and stack");
   }
+
+  /* =============== FLASH =============== */
+  .text : {
+    *(.text .text.* )
+  }  > FLASH
+
 }

--- a/cmake/targets/etiss/etiss.ld.in
+++ b/cmake/targets/etiss/etiss.ld.in
@@ -20,7 +20,6 @@ MEMORY
 {
   ROM  (rx)  : ORIGIN = @MEM_ROM_ORIGIN@, LENGTH = @MEM_ROM_LENGTH@
   RAM  (rw) : ORIGIN = @MEM_RAM_ORIGIN@, LENGTH = @MEM_RAM_LENGTH@
-  FLASH  (rw) : ORIGIN = @MEM_FLASH_ORIGIN@, LENGTH = @MEM_FLASH_LENGTH@
 }
 
 
@@ -37,6 +36,10 @@ _heap_end        = _stack_start;
 SECTIONS
 {
   /* ================ ROM ================ */
+
+  .text : {
+    *(.text .text.* )
+  }  > ROM
 
   .rodata : {
     *(.rodata .rodata.*)
@@ -97,10 +100,4 @@ SECTIONS
   .stack : {
     ASSERT ((__stack > (_end + __heap_size + __stack_size)), "Error: RAM too small for heap and stack");
   }
-
-  /* =============== FLASH =============== */
-  .text : {
-    *(.text .text.* )
-  }  > FLASH
-
 }

--- a/cmake/targets/etiss/etiss_wFlash.ld.in
+++ b/cmake/targets/etiss/etiss_wFlash.ld.in
@@ -1,0 +1,106 @@
+/*
+// Copyright 2017 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the “License”); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// This file was modified by the Chair of Electronic Design Automation, TUM
+*/
+
+ENTRY(_start)
+SEARCH_DIR(.)
+
+
+MEMORY
+{
+  ROM  (rx)  : ORIGIN = @MEM_ROM_ORIGIN@, LENGTH = @MEM_ROM_LENGTH@
+  RAM  (rw) : ORIGIN = @MEM_RAM_ORIGIN@, LENGTH = @MEM_RAM_LENGTH@
+  FLASH  (rw) : ORIGIN = @MEM_FLASH_ORIGIN@, LENGTH = @MEM_FLASH_LENGTH@
+}
+
+
+/* minimum sizes for heap and stack. It will be checked that they can fit on the RAM */
+__stack_size     = @MIN_STACK_SIZE@;
+__heap_size      = @MIN_HEAP_SIZE@;
+
+/* kept for compitibility with get_metrics.py */
+_stack_start     = ORIGIN(RAM) + LENGTH(RAM);
+_heap_start      = _bss_end;
+_heap_end        = _stack_start;
+
+
+SECTIONS
+{
+  /* ================ ROM ================ */
+
+  .rodata : {
+    *(.rodata .rodata.*)
+  } > ROM
+  .srodata : {
+    *(.srodata .srodata.*)
+  } > ROM
+
+
+
+  /* ================ RAM ================ */
+
+  .init_array : {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(.init_array .init_array.*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } > RAM
+  .fini_array : {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(.fini_array .fini_array.*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } > RAM
+
+  .gcc_except_table : {
+    *(.gcc_except_table .gcc_except_table.*)
+  } > RAM
+
+  .eh_frame : {
+    KEEP (*(.eh_frame))
+  } > RAM
+
+  __data_start = .;
+  .data : {
+      *(.data .data.*)
+  } > RAM
+  __sdata_start = .;
+  .sdata : {
+      *(.sdata .sdata.*)
+  } > RAM
+  _edata = .; PROVIDE (edata = .);
+  __bss_start = .;
+  .sbss : {
+      *(.sbss .sbss.*)
+  } > RAM
+  .bss : {
+      *(.bss .bss.*)
+      _bss_end = .;
+  } > RAM
+  _end = .;
+
+  /* do not place anything after this address, because the heap starts here! */
+
+  /* point the global pointer so it can access sdata, sbss, data and bss */
+  __global_pointer$ = MIN(__sdata_start + 0x800, MAX(__data_start + 0x800, _end - 0x800));
+
+  /* stack pointer starts at the top of the ram */
+  __stack = ORIGIN(RAM) + LENGTH(RAM);
+  .stack : {
+    ASSERT ((__stack > (_end + __heap_size + __stack_size)), "Error: RAM too small for heap and stack");
+  }
+
+  /* =============== FLASH =============== */
+  .text : {
+    *(.text .text.* )
+  }  > FLASH
+
+}


### PR DESCRIPTION
- Add another linker template that links text section to FLASH region
- Allow cmake to choose between normal template and flash template based on user input. 